### PR TITLE
[CREATIVE] Add visual tuning feedback with pitch detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk
+.apdisk.worktrees/
+.claude-output/

--- a/.gitignore
+++ b/.gitignore
@@ -168,5 +168,6 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk.worktrees/
+.apdisk
+.worktrees/
 .claude-output/

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/makingiants/android/banjotuner/EarActivity.kt
+++ b/app/src/main/java/com/makingiants/android/banjotuner/EarActivity.kt
@@ -1,10 +1,17 @@
 package com.makingiants.android.banjotuner
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
 import android.os.Bundle
 import android.util.Log
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.core.FastOutLinearInEasing
@@ -14,22 +21,42 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,35 +64,30 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.MobileAds
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.VolumeOff
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.IOException
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 class EarActivity : AppCompatActivity() {
     @VisibleForTesting
     internal val player by lazy { SoundPlayer(this) }
+
+    private val pitchDetector by lazy { PitchDetector() }
 
     private val buttonsText =
         listOf(
@@ -75,10 +97,20 @@ class EarActivity : AppCompatActivity() {
             R.string.ear_button_1_text,
         )
 
+    private val banjoStrings =
+        listOf(
+            BanjoString.D3,
+            BanjoString.G3,
+            BanjoString.B3,
+            BanjoString.D4,
+        )
+
     @VisibleForTesting
     internal val clickAnimation: Animation by lazy {
         AnimationUtils.loadAnimation(this, R.anim.shake_animation)
     }
+
+    private var audioRecord: AudioRecord? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -89,7 +121,17 @@ class EarActivity : AppCompatActivity() {
 
     override fun onPause() {
         player.stop()
+        stopAudioCapture()
         super.onPause()
+    }
+
+    private fun stopAudioCapture() {
+        try {
+            audioRecord?.stop()
+        } catch (_: IllegalStateException) {
+        }
+        audioRecord?.release()
+        audioRecord = null
     }
 
     @Composable
@@ -117,15 +159,19 @@ class EarActivity : AppCompatActivity() {
     @Composable
     fun MainLayout() {
         val snackbarHostState = remember { SnackbarHostState() }
+        val pitchCheckMode = remember { mutableStateOf(false) }
+        val pitchResult = remember { mutableStateOf<PitchResult?>(null) }
+        val selectedStringIndex = remember { mutableIntStateOf(-1) }
 
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
             containerColor = colorResource(id = R.color.banjen_background),
         ) { paddingValues ->
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
             ) {
                 Column(
                     modifier = Modifier.fillMaxSize(),
@@ -136,11 +182,182 @@ class EarActivity : AppCompatActivity() {
                     val isVolumeLow = remember { mutableStateOf(false) }
 
                     buttonsText.forEachIndexed { index, text ->
-                        Button(index, text, selectedOption, isVolumeLow, snackbarHostState)
+                        Button(
+                            index,
+                            text,
+                            selectedOption,
+                            isVolumeLow,
+                            snackbarHostState,
+                            pitchCheckMode,
+                            pitchResult,
+                            selectedStringIndex,
+                        )
+                    }
+
+                    if (pitchCheckMode.value) {
+                        TuningIndicator(pitchResult.value)
                     }
 
                     AdView()
                 }
+            }
+        }
+
+        // Audio capture effect
+        if (pitchCheckMode.value && selectedStringIndex.intValue >= 0) {
+            val targetString = banjoStrings[selectedStringIndex.intValue]
+            AudioCaptureEffect(targetString, pitchResult)
+        }
+    }
+
+    @Composable
+    private fun AudioCaptureEffect(
+        targetString: BanjoString,
+        pitchResult: MutableState<PitchResult?>,
+    ) {
+        val sampleRate = 44100
+        val bufferSize = 4096
+
+        DisposableEffect(targetString) {
+            onDispose {
+                stopAudioCapture()
+            }
+        }
+
+        LaunchedEffect(targetString) {
+            withContext(Dispatchers.IO) {
+                val minBufferSize =
+                    AudioRecord.getMinBufferSize(
+                        sampleRate,
+                        AudioFormat.CHANNEL_IN_MONO,
+                        AudioFormat.ENCODING_PCM_FLOAT,
+                    )
+                val actualBufferSize = maxOf(bufferSize, minBufferSize)
+
+                val recorder =
+                    try {
+                        AudioRecord(
+                            MediaRecorder.AudioSource.MIC,
+                            sampleRate,
+                            AudioFormat.CHANNEL_IN_MONO,
+                            AudioFormat.ENCODING_PCM_FLOAT,
+                            actualBufferSize * 4,
+                        )
+                    } catch (e: SecurityException) {
+                        Log.e("EarActivity", "Microphone permission not granted", e)
+                        return@withContext
+                    }
+
+                if (recorder.state != AudioRecord.STATE_INITIALIZED) {
+                    recorder.release()
+                    return@withContext
+                }
+
+                audioRecord = recorder
+                recorder.startRecording()
+
+                val buffer = FloatArray(bufferSize)
+                while (isActive) {
+                    val read = recorder.read(buffer, 0, bufferSize, AudioRecord.READ_BLOCKING)
+                    if (read > 0) {
+                        val detectedHz = pitchDetector.detectPitch(buffer)
+                        val result =
+                            if (detectedHz > 0) {
+                                val cents = pitchDetector.centsFromTarget(detectedHz, targetString.frequencyHz)
+                                PitchResult(
+                                    detectedHz = detectedHz,
+                                    targetHz = targetString.frequencyHz,
+                                    centDeviation = cents,
+                                    status = pitchDetector.classifyTuning(cents),
+                                )
+                            } else {
+                                PitchResult(
+                                    detectedHz = 0.0,
+                                    targetHz = targetString.frequencyHz,
+                                    centDeviation = 0.0,
+                                    status = TuningStatus.NO_SIGNAL,
+                                )
+                            }
+                        withContext(Dispatchers.Main) {
+                            pitchResult.value = result
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun TuningIndicator(result: PitchResult?) {
+        val accentColor = colorResource(id = R.color.banjen_accent)
+
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp, vertical = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            if (result == null || result.status == TuningStatus.NO_SIGNAL) {
+                Text(
+                    text = stringResource(R.string.no_signal),
+                    style = TextStyle(fontSize = 16.sp, color = accentColor),
+                )
+            } else {
+                val indicatorColor =
+                    when (result.status) {
+                        TuningStatus.IN_TUNE -> Color(0xFF4CAF50)
+                        TuningStatus.CLOSE -> Color(0xFFFFC107)
+                        TuningStatus.SHARP, TuningStatus.FLAT -> Color(0xFFF44336)
+                        TuningStatus.NO_SIGNAL -> Color.Gray
+                    }
+
+                // Direction arrow
+                if (result.status == TuningStatus.SHARP || (result.status == TuningStatus.CLOSE && result.centDeviation > 0)) {
+                    Text(
+                        text = stringResource(R.string.tune_down),
+                        style = TextStyle(fontSize = 14.sp, color = indicatorColor),
+                    )
+                } else if (result.status == TuningStatus.FLAT || (result.status == TuningStatus.CLOSE && result.centDeviation < 0)) {
+                    Text(
+                        text = stringResource(R.string.tune_up),
+                        style = TextStyle(fontSize = 14.sp, color = indicatorColor),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Colored indicator bar
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth(0.7f)
+                            .height(12.dp)
+                            .background(indicatorColor, RoundedCornerShape(6.dp)),
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Status text
+                val statusText =
+                    when (result.status) {
+                        TuningStatus.IN_TUNE -> stringResource(R.string.in_tune)
+                        else -> {
+                            val cents = abs(result.centDeviation).roundToInt()
+                            val direction = if (result.centDeviation > 0) "+" else "-"
+                            "${direction}$cents cents"
+                        }
+                    }
+
+                Text(
+                    text = statusText,
+                    style =
+                        TextStyle(
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = indicatorColor,
+                        ),
+                )
             }
         }
     }
@@ -168,18 +385,32 @@ class EarActivity : AppCompatActivity() {
         selectedOption: MutableState<Int>,
         isVolumeLow: MutableState<Boolean>,
         snackbarHostState: SnackbarHostState,
+        pitchCheckMode: MutableState<Boolean>,
+        pitchResult: MutableState<PitchResult?>,
+        selectedStringIndex: MutableState<Int>,
     ) {
         val isSelected = selectedOption.value == text
         val scope = rememberCoroutineScope()
         val volumeLowMessage = stringResource(id = R.string.volume_low_message)
 
+        val permissionLauncher =
+            rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestPermission(),
+            ) { granted ->
+                if (granted) {
+                    player.stop()
+                    pitchCheckMode.value = true
+                    pitchResult.value = null
+                }
+            }
+
         val scaleAnimation by animateFloatAsState(
-            targetValue = if (isSelected) 3f else 1f,
+            targetValue = if (isSelected && !pitchCheckMode.value) 3f else 1f,
             label = "scale animation",
         )
         val shakeAnimation by rememberInfiniteTransition(label = "infinite").animateFloat(
-            initialValue = if (isSelected) -10f else 0f,
-            targetValue = if (isSelected) 10f else 0f,
+            initialValue = if (isSelected && !pitchCheckMode.value) -10f else 0f,
+            targetValue = if (isSelected && !pitchCheckMode.value) 10f else 0f,
             animationSpec =
                 infiniteRepeatable(
                     animation = tween(100, easing = FastOutLinearInEasing),
@@ -188,21 +419,23 @@ class EarActivity : AppCompatActivity() {
             label = "shake animation",
         )
 
-        val showVolumeIcon = isSelected && isVolumeLow.value
-        val iconShakeAnimation = if (showVolumeIcon) {
-            rememberInfiniteTransition(label = "icon-infinite").animateFloat(
-                initialValue = -5f,
-                targetValue = 5f,
-                animationSpec =
-                    infiniteRepeatable(
-                        animation = tween(100, easing = FastOutLinearInEasing),
-                        repeatMode = RepeatMode.Reverse,
-                    ),
-                label = "icon shake animation",
-            ).value
-        } else {
-            0f
-        }
+        val showVolumeIcon = isSelected && isVolumeLow.value && !pitchCheckMode.value
+        val iconShakeAnimation =
+            if (showVolumeIcon) {
+                rememberInfiniteTransition(label = "icon-infinite")
+                    .animateFloat(
+                        initialValue = -5f,
+                        targetValue = 5f,
+                        animationSpec =
+                            infiniteRepeatable(
+                                animation = tween(100, easing = FastOutLinearInEasing),
+                                repeatMode = RepeatMode.Reverse,
+                            ),
+                        label = "icon shake animation",
+                    ).value
+            } else {
+                0f
+            }
 
         TextButton(
             modifier =
@@ -215,10 +448,38 @@ class EarActivity : AppCompatActivity() {
                         translationX = shakeAnimation,
                     ),
             onClick = {
+                // If in pitch check mode, exit it and resume tone
+                if (pitchCheckMode.value) {
+                    pitchCheckMode.value = false
+                    pitchResult.value = null
+                    stopAudioCapture()
+
+                    val selectedValue = selectedOption.value
+                    if (selectedValue != text) {
+                        selectedOption.value = text
+                        selectedStringIndex.value = index
+                        isVolumeLow.value = player.isVolumeLow()
+                        try {
+                            player.playWithLoop(index)
+                        } catch (e: IOException) {
+                            Log.e("EarActivity", "Playing sound", e)
+                        }
+                    } else {
+                        // Resume playing the same string
+                        try {
+                            player.playWithLoop(index)
+                        } catch (e: IOException) {
+                            Log.e("EarActivity", "Playing sound", e)
+                        }
+                    }
+                    return@TextButton
+                }
+
                 val selectedValue = selectedOption.value
 
                 if (selectedValue != text) {
                     selectedOption.value = text
+                    selectedStringIndex.value = index
                     isVolumeLow.value = player.isVolumeLow()
 
                     try {
@@ -229,6 +490,7 @@ class EarActivity : AppCompatActivity() {
                 } else {
                     player.stop()
                     selectedOption.value = -1
+                    selectedStringIndex.value = -1
                     isVolumeLow.value = false
                 }
             },
@@ -243,9 +505,10 @@ class EarActivity : AppCompatActivity() {
                                 snackbarHostState.showSnackbar(volumeLowMessage)
                             }
                         },
-                        modifier = Modifier
-                            .size(48.dp)
-                            .graphicsLayer(translationX = iconShakeAnimation),
+                        modifier =
+                            Modifier
+                                .size(48.dp)
+                                .graphicsLayer(translationX = iconShakeAnimation),
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.VolumeOff,
@@ -265,6 +528,47 @@ class EarActivity : AppCompatActivity() {
                             textAlign = TextAlign.Center,
                         ),
                 )
+                // Show mic icon for pitch check when this string is selected and playing
+                if (isSelected && !pitchCheckMode.value) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    IconButton(
+                        onClick = {
+                            val hasPermission =
+                                ContextCompat.checkSelfPermission(
+                                    this@EarActivity,
+                                    Manifest.permission.RECORD_AUDIO,
+                                ) == PackageManager.PERMISSION_GRANTED
+
+                            if (hasPermission) {
+                                player.stop()
+                                pitchCheckMode.value = true
+                                pitchResult.value = null
+                            } else {
+                                permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                            }
+                        },
+                        modifier = Modifier.size(36.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Mic,
+                            contentDescription = stringResource(R.string.check_tuning_button),
+                            tint = colorResource(id = R.color.banjen_accent),
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+                // Show stop checking button when in pitch check mode for this string
+                if (isSelected && pitchCheckMode.value) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = stringResource(R.string.stop_checking),
+                        style =
+                            TextStyle(
+                                fontSize = 12.sp,
+                                color = Color(0xFFF44336),
+                            ),
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/makingiants/android/banjotuner/PitchDetector.kt
+++ b/app/src/main/java/com/makingiants/android/banjotuner/PitchDetector.kt
@@ -1,0 +1,121 @@
+package com.makingiants.android.banjotuner
+
+import kotlin.math.abs
+
+class PitchDetector(
+    private val sampleRate: Int = 44100,
+) {
+    private val yinThreshold = 0.15
+
+    /**
+     * Detects the fundamental frequency of the given audio samples using the YIN algorithm.
+     * Returns the detected frequency in Hz, or -1.0 if no pitch is detected.
+     */
+    fun detectPitch(samples: FloatArray): Double {
+        val halfLen = samples.size / 2
+        val yinBuffer = FloatArray(halfLen)
+
+        // Step 1: Difference function
+        for (tau in 0 until halfLen) {
+            var sum = 0.0f
+            for (i in 0 until halfLen) {
+                val diff = samples[i] - samples[i + tau]
+                sum += diff * diff
+            }
+            yinBuffer[tau] = sum
+        }
+
+        // Step 2: Cumulative mean normalized difference
+        yinBuffer[0] = 1.0f
+        var runningSum = 0.0f
+        for (tau in 1 until halfLen) {
+            runningSum += yinBuffer[tau]
+            yinBuffer[tau] = yinBuffer[tau] * tau / runningSum
+        }
+
+        // Step 3: Absolute threshold — find first dip below threshold, then local minimum
+        var tauEstimate = -1
+        for (tau in 2 until halfLen) {
+            if (yinBuffer[tau] < yinThreshold) {
+                tauEstimate = tau
+                // Walk forward to find the local minimum in this dip
+                while (tauEstimate + 1 < halfLen && yinBuffer[tauEstimate + 1] < yinBuffer[tauEstimate]) {
+                    tauEstimate++
+                }
+                break
+            }
+        }
+
+        if (tauEstimate == -1) return -1.0
+
+        // Step 4: Parabolic interpolation for sub-sample accuracy
+        val refinedTau = parabolicInterpolation(yinBuffer, tauEstimate)
+
+        // Step 5: Convert to frequency
+        return sampleRate.toDouble() / refinedTau
+    }
+
+    private fun parabolicInterpolation(
+        yinBuffer: FloatArray,
+        tau: Int,
+    ): Double {
+        if (tau <= 0 || tau >= yinBuffer.size - 1) return tau.toDouble()
+
+        val s0 = yinBuffer[tau - 1].toDouble()
+        val s1 = yinBuffer[tau].toDouble()
+        val s2 = yinBuffer[tau + 1].toDouble()
+
+        val adjustment = (s2 - s0) / (2.0 * (2.0 * s1 - s2 - s0))
+        return tau + adjustment
+    }
+
+    /**
+     * Calculates the deviation in cents between detected and target frequencies.
+     * Negative = flat, positive = sharp.
+     */
+    fun centsFromTarget(
+        detected: Double,
+        target: Double,
+    ): Double {
+        if (detected <= 0 || target <= 0) return 0.0
+        return 1200.0 * (Math.log(detected / target) / Math.log(2.0))
+    }
+
+    /**
+     * Classifies tuning status based on cent deviation.
+     */
+    fun classifyTuning(cents: Double): TuningStatus {
+        val absCents = abs(cents)
+        return when {
+            absCents <= 10.0 -> TuningStatus.IN_TUNE
+            absCents <= 25.0 -> TuningStatus.CLOSE
+            cents > 0 -> TuningStatus.SHARP
+            else -> TuningStatus.FLAT
+        }
+    }
+}
+
+enum class TuningStatus {
+    IN_TUNE,
+    CLOSE,
+    SHARP,
+    FLAT,
+    NO_SIGNAL,
+}
+
+data class PitchResult(
+    val detectedHz: Double,
+    val targetHz: Double,
+    val centDeviation: Double,
+    val status: TuningStatus,
+)
+
+enum class BanjoString(
+    val noteName: String,
+    val frequencyHz: Double,
+) {
+    D4("D", 293.66),
+    B3("B", 246.94),
+    G3("G", 196.00),
+    D3("D", 146.83),
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,4 +5,11 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">El volumen está bajo. Súbelo para escuchar los tonos de afinación.</string>
+  <string name="check_tuning_button">Verificar Afinación</string>
+  <string name="mic_permission_rationale">Se necesita acceso al micrófono para verificar tu afinación.</string>
+  <string name="tune_up">Sube \u25B2</string>
+  <string name="tune_down">Baja \u25BC</string>
+  <string name="in_tune">\u00A1Afinado!</string>
+  <string name="no_signal">Toca la cuerda\u2026</string>
+  <string name="stop_checking">Dejar de Verificar</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,4 +5,11 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">Il volume è basso. Alzalo per sentire i toni di accordatura.</string>
+  <string name="check_tuning_button">Controlla Accordatura</string>
+  <string name="mic_permission_rationale">È necessario l\'accesso al microfono per controllare l\'accordatura.</string>
+  <string name="tune_up">Alza \u25B2</string>
+  <string name="tune_down">Abbassa \u25BC</string>
+  <string name="in_tune">Accordato!</string>
+  <string name="no_signal">Suona la corda\u2026</string>
+  <string name="stop_checking">Smetti di Controllare</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -5,4 +5,11 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">O volume está baixo. Aumente para ouvir os tons de afinação.</string>
+  <string name="check_tuning_button">Verificar Afinação</string>
+  <string name="mic_permission_rationale">Acesso ao microfone é necessário para verificar sua afinação.</string>
+  <string name="tune_up">Suba \u25B2</string>
+  <string name="tune_down">Baixe \u25BC</string>
+  <string name="in_tune">Afinado!</string>
+  <string name="no_signal">Toque a corda\u2026</string>
+  <string name="stop_checking">Parar de Verificar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,11 @@
   <string name="ear_button_3_text">3 - G</string>
   <string name="ear_button_4_text">4 - D</string>
   <string name="volume_low_message">Volume is low. Turn it up to hear the tuning tones.</string>
+  <string name="check_tuning_button">Check My Tuning</string>
+  <string name="mic_permission_rationale">Microphone access is needed to check your tuning.</string>
+  <string name="tune_up">Tune Up \u25B2</string>
+  <string name="tune_down">Tune Down \u25BC</string>
+  <string name="in_tune">In Tune!</string>
+  <string name="no_signal">Play your string\u2026</string>
+  <string name="stop_checking">Stop Checking</string>
 </resources>

--- a/app/src/test/java/com/makingiants/android/banjotuner/PitchDetectorTest.kt
+++ b/app/src/test/java/com/makingiants/android/banjotuner/PitchDetectorTest.kt
@@ -1,0 +1,107 @@
+package com.makingiants.android.banjotuner
+
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sin
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PitchDetectorTest {
+    private val sampleRate = 44100
+    private val detector = PitchDetector(sampleRate)
+
+    private fun generateSineWave(
+        frequencyHz: Double,
+        numSamples: Int = 4096,
+    ): FloatArray =
+        FloatArray(numSamples) { i ->
+            sin(2.0 * PI * frequencyHz * i / sampleRate).toFloat()
+        }
+
+    @Test
+    fun `detectPitch returns correct frequency for A4 440Hz sine wave`() {
+        val samples = generateSineWave(440.0)
+        val detected = detector.detectPitch(samples)
+        assertTrue(detected > 0, "Expected positive frequency, got $detected")
+        assertTrue(abs(detected - 440.0) < 5.0, "Expected ~440Hz, got $detected")
+    }
+
+    @Test
+    fun `detectPitch returns correct frequency for D4 293Hz banjo string`() {
+        val samples = generateSineWave(293.66)
+        val detected = detector.detectPitch(samples)
+        assertTrue(abs(detected - 293.66) < 3.0, "Expected ~293.66Hz, got $detected")
+    }
+
+    @Test
+    fun `detectPitch returns correct frequency for B3 247Hz banjo string`() {
+        val samples = generateSineWave(246.94)
+        val detected = detector.detectPitch(samples)
+        assertTrue(abs(detected - 246.94) < 3.0, "Expected ~246.94Hz, got $detected")
+    }
+
+    @Test
+    fun `detectPitch returns correct frequency for G3 196Hz banjo string`() {
+        val samples = generateSineWave(196.00)
+        val detected = detector.detectPitch(samples)
+        assertTrue(abs(detected - 196.00) < 3.0, "Expected ~196.00Hz, got $detected")
+    }
+
+    @Test
+    fun `detectPitch returns correct frequency for D3 147Hz banjo string`() {
+        val samples = generateSineWave(146.83, numSamples = 8192)
+        val detected = detector.detectPitch(samples)
+        assertTrue(abs(detected - 146.83) < 3.0, "Expected ~146.83Hz, got $detected")
+    }
+
+    @Test
+    fun `detectPitch returns negative for silence`() {
+        val samples = FloatArray(4096) { 0.0f }
+        val detected = detector.detectPitch(samples)
+        assertTrue(detected < 0, "Expected no pitch for silence, got $detected")
+    }
+
+    @Test
+    fun `centsFromTarget returns zero for exact match`() {
+        val cents = detector.centsFromTarget(440.0, 440.0)
+        assertEquals(0.0, cents, 0.001)
+    }
+
+    @Test
+    fun `centsFromTarget returns positive for sharp`() {
+        val cents = detector.centsFromTarget(450.0, 440.0)
+        assertTrue(cents > 0, "Expected positive cents for sharp, got $cents")
+    }
+
+    @Test
+    fun `centsFromTarget returns negative for flat`() {
+        val cents = detector.centsFromTarget(430.0, 440.0)
+        assertTrue(cents < 0, "Expected negative cents for flat, got $cents")
+    }
+
+    @Test
+    fun `classifyTuning returns IN_TUNE within 10 cents`() {
+        assertEquals(TuningStatus.IN_TUNE, detector.classifyTuning(0.0))
+        assertEquals(TuningStatus.IN_TUNE, detector.classifyTuning(5.0))
+        assertEquals(TuningStatus.IN_TUNE, detector.classifyTuning(-10.0))
+    }
+
+    @Test
+    fun `classifyTuning returns CLOSE within 25 cents`() {
+        assertEquals(TuningStatus.CLOSE, detector.classifyTuning(15.0))
+        assertEquals(TuningStatus.CLOSE, detector.classifyTuning(-20.0))
+    }
+
+    @Test
+    fun `classifyTuning returns SHARP beyond 25 cents positive`() {
+        assertEquals(TuningStatus.SHARP, detector.classifyTuning(30.0))
+        assertEquals(TuningStatus.SHARP, detector.classifyTuning(50.0))
+    }
+
+    @Test
+    fun `classifyTuning returns FLAT beyond 25 cents negative`() {
+        assertEquals(TuningStatus.FLAT, detector.classifyTuning(-30.0))
+        assertEquals(TuningStatus.FLAT, detector.classifyTuning(-50.0))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds optional microphone-based pitch detection using YIN algorithm (pure Kotlin, no external dependencies)
- Visual tuning indicator shows green/yellow/red color coding with directional arrows (tune up/down)
- Includes RECORD_AUDIO runtime permission handling with graceful degradation

## User Problem Solved
Harold M. (beginner) "cannot tell if his banjo is in tune. His ear is untrained and he does not trust it." This feature provides a visual "confidence bridge" that confirms tuning without replacing the pedagogically superior reference tone approach. Betty L. also benefits from confirmation of her relative pitch.

## Changes
- `app/src/main/java/.../PitchDetector.kt` — NEW: YIN pitch detection algorithm, cent deviation calculator, tuning status classifier, data models (BanjoString, PitchResult, TuningStatus)
- `app/src/main/java/.../EarActivity.kt` — Added pitch check mode with AudioRecord capture, TuningIndicator composable, mic icon button on selected strings, permission launcher
- `app/src/main/AndroidManifest.xml` — Added RECORD_AUDIO permission
- `app/src/main/res/values/strings.xml` — Added 7 new strings for tuning UI
- `app/src/main/res/values-es/strings.xml` — Spanish localization
- `app/src/main/res/values-pt/strings.xml` — Portuguese localization
- `app/src/main/res/values-it/strings.xml` — Italian localization
- `app/src/test/java/.../PitchDetectorTest.kt` — NEW: 13 unit tests covering all 4 banjo string frequencies, cent calculation, tuning classification, and silence handling

## Artifacts
- Investigation: /Users/dan/projects/banjen/.claude-output/product-team/features/visual-tuning-feedback/1-investigation.md
- Plan: /Users/dan/projects/banjen/.claude-output/product-team/features/visual-tuning-feedback/2-plan.md

## How to Test
1. Build and install: `./gradlew installDebug`
2. Tap any string button to play reference tone
3. Tap the mic icon that appears next to the selected string
4. Grant microphone permission when prompted
5. Play the corresponding banjo string near the device
6. Observe the colored indicator: green (in tune), yellow (close), red (sharp/flat) with directional arrows
7. Tap the string button again to return to reference tone mode
8. Unit tests: `./gradlew test` (13 tests, no device needed)

## Council Endorsement
**Product Council**: The Chief Product Strategist identifies this as a "confidence bridge" that keeps beginners like Harold from churning while still promoting ear training (reference tones remain primary). The Strategic Growth Advisor notes this is a major competitive differentiator: no other reference-tone tuner offers integrated pitch verification. The Head of Product Ops points out that "tuning confidence" could be a measurable retention metric.

**Engineering Council**: The Distinguished Engineer confirms that YIN pitch detection is a well-studied algorithm that can be implemented in pure Kotlin (~100-150 lines) using AudioRecord, requiring no native code or external libraries. The R&D Principal Staff Engineer notes that Android's AudioRecord API is stable and well-supported from API 23+. The Lean Engineering Lead flags this as L complexity due to signal processing nuance (handling harmonics, noise) and the new permission flow, but confirms it's achievable by a single engineer.

🤖 Generated by product-engineers-team skill