### PR TITLE
[CREATIVE] Add session mode for discreet earbud-optimized tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk
+.apdisk.worktrees/
+.claude-output/

--- a/.gitignore
+++ b/.gitignore
@@ -168,5 +168,6 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk.worktrees/
+.apdisk
+.worktrees/
 .claude-output/

--- a/app/src/main/java/com/makingiants/android/banjotuner/EarActivity.kt
+++ b/app/src/main/java/com/makingiants/android/banjotuner/EarActivity.kt
@@ -1,9 +1,11 @@
 package com.makingiants.android.banjotuner
 
+import android.content.Context
 import android.os.Bundle
 import android.util.Log
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -14,58 +16,74 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.filled.Headphones
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableFloatState
+import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.MobileAds
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.VolumeOff
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.io.IOException
 
 class EarActivity : AppCompatActivity() {
     @VisibleForTesting
     internal val player by lazy { SoundPlayer(this) }
+
+    private val prefs by lazy { getSharedPreferences(SESSION_PREFS_NAME, Context.MODE_PRIVATE) }
 
     private val buttonsText =
         listOf(
@@ -75,21 +93,54 @@ class EarActivity : AppCompatActivity() {
             R.string.ear_button_1_text,
         )
 
+    private val sessionStringNames =
+        listOf(
+            R.string.session_string_1,
+            R.string.session_string_2,
+            R.string.session_string_3,
+            R.string.session_string_4,
+        )
+
     @VisibleForTesting
     internal val clickAnimation: Animation by lazy {
         AnimationUtils.loadAnimation(this, R.anim.shake_animation)
     }
 
+    private var sessionModeActive = mutableStateOf(false)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    if (sessionModeActive.value) {
+                        exitSessionMode()
+                    } else {
+                        isEnabled = false
+                        onBackPressedDispatcher.onBackPressed()
+                    }
+                }
+            },
+        )
 
         MobileAds.initialize(this)
         setContent { Contents() }
     }
 
     override fun onPause() {
+        if (sessionModeActive.value) {
+            exitSessionMode()
+        }
         player.stop()
         super.onPause()
+    }
+
+    private fun exitSessionMode() {
+        sessionModeActive.value = false
+        player.stop()
+        player.volume = 1.0f
     }
 
     @Composable
@@ -118,14 +169,27 @@ class EarActivity : AppCompatActivity() {
     fun MainLayout() {
         val snackbarHostState = remember { SnackbarHostState() }
 
+        if (sessionModeActive.value) {
+            SessionModeLayout(snackbarHostState)
+        } else {
+            NormalLayout(snackbarHostState)
+        }
+    }
+
+    @Composable
+    private fun NormalLayout(snackbarHostState: SnackbarHostState) {
+        val scope = rememberCoroutineScope()
+        val noHeadphonesMsg = stringResource(id = R.string.session_no_headphones)
+
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
             containerColor = colorResource(id = R.color.banjen_background),
         ) { paddingValues ->
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
             ) {
                 Column(
                     modifier = Modifier.fillMaxSize(),
@@ -135,6 +199,19 @@ class EarActivity : AppCompatActivity() {
                     val selectedOption = remember { mutableIntStateOf(-1) }
                     val isVolumeLow = remember { mutableStateOf(false) }
 
+                    SessionModeToggle {
+                        if (!player.isHeadphoneConnected()) {
+                            scope.launch {
+                                snackbarHostState.showSnackbar(noHeadphonesMsg)
+                            }
+                        }
+                        val savedVol = prefs.getFloat(KEY_SESSION_VOLUME, DEFAULT_SESSION_VOLUME)
+                        player.volume = savedVol
+                        player.stop()
+                        selectedOption.intValue = -1
+                        sessionModeActive.value = true
+                    }
+
                     buttonsText.forEachIndexed { index, text ->
                         Button(index, text, selectedOption, isVolumeLow, snackbarHostState)
                     }
@@ -142,6 +219,187 @@ class EarActivity : AppCompatActivity() {
                     AdView()
                 }
             }
+        }
+    }
+
+    @Composable
+    private fun SessionModeToggle(onActivate: () -> Unit) {
+        val label = stringResource(id = R.string.session_mode_label)
+
+        TextButton(
+            onClick = onActivate,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Headphones,
+                    contentDescription = label,
+                    tint = colorResource(id = R.color.banjen_accent),
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = label,
+                    style =
+                        TextStyle(
+                            fontSize = 14.sp,
+                            color = colorResource(id = R.color.banjen_accent),
+                        ),
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun SessionModeLayout(snackbarHostState: SnackbarHostState) {
+        val currentStringIndex = remember { mutableIntStateOf(0) }
+        val sessionRunning = remember { mutableStateOf(true) }
+        val savedVol = prefs.getFloat(KEY_SESSION_VOLUME, DEFAULT_SESSION_VOLUME)
+        val sessionVolume = remember { mutableFloatStateOf(savedVol) }
+        val stopLabel = stringResource(id = R.string.session_stop)
+
+        LaunchedEffect(sessionRunning.value) {
+            if (!sessionRunning.value) return@LaunchedEffect
+
+            var index = 0
+            while (index <= 3 && sessionRunning.value) {
+                currentStringIndex.intValue = index
+                player.volume = sessionVolume.floatValue
+                try {
+                    player.playWithLoop(index)
+                } catch (e: IOException) {
+                    Log.e("EarActivity", "Session mode playback", e)
+                }
+                delay(SECONDS_PER_STRING * 1000L)
+                val next = autoAdvanceNextIndex(index)
+                if (next != null) {
+                    index = next
+                } else {
+                    sessionRunning.value = false
+                    player.stop()
+                }
+            }
+        }
+
+        Scaffold(
+            snackbarHost = { SnackbarHost(snackbarHostState) },
+            containerColor = Color.Black,
+        ) { paddingValues ->
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = getString(sessionStringNames[currentStringIndex.intValue]),
+                    style =
+                        TextStyle(
+                            fontSize = 48.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color.White,
+                            textAlign = TextAlign.Center,
+                        ),
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                ProgressDots(currentStringIndex)
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                VolumeSlider(sessionVolume)
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                TextButton(
+                    onClick = {
+                        exitSessionMode()
+                    },
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Stop,
+                            contentDescription = stopLabel,
+                            tint = Color.White,
+                            modifier = Modifier.size(24.dp),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = stopLabel,
+                            style =
+                                TextStyle(
+                                    fontSize = 18.sp,
+                                    color = Color.White,
+                                ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun ProgressDots(currentStringIndex: MutableIntState) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            for (i in 0..3) {
+                val isActive = i <= currentStringIndex.intValue
+                Box(
+                    modifier =
+                        Modifier
+                            .size(12.dp)
+                            .clip(CircleShape)
+                            .background(if (isActive) Color.White else Color.DarkGray),
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun VolumeSlider(sessionVolume: MutableFloatState) {
+        val volumeLabel = stringResource(id = R.string.session_volume_label)
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(horizontal = 48.dp),
+        ) {
+            Text(
+                text = volumeLabel,
+                style =
+                    TextStyle(
+                        fontSize = 14.sp,
+                        color = Color.Gray,
+                    ),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Slider(
+                value = sessionVolume.floatValue,
+                onValueChange = { newVolume ->
+                    val clamped = clampVolume(newVolume)
+                    sessionVolume.floatValue = clamped
+                    player.volume = clamped
+                    prefs.edit().putFloat(KEY_SESSION_VOLUME, clamped).apply()
+                },
+                valueRange = 0.05f..1.0f,
+                colors =
+                    SliderDefaults.colors(
+                        thumbColor = Color.White,
+                        activeTrackColor = Color.White,
+                        inactiveTrackColor = Color.DarkGray,
+                    ),
+            )
         }
     }
 
@@ -189,20 +447,22 @@ class EarActivity : AppCompatActivity() {
         )
 
         val showVolumeIcon = isSelected && isVolumeLow.value
-        val iconShakeAnimation = if (showVolumeIcon) {
-            rememberInfiniteTransition(label = "icon-infinite").animateFloat(
-                initialValue = -5f,
-                targetValue = 5f,
-                animationSpec =
-                    infiniteRepeatable(
-                        animation = tween(100, easing = FastOutLinearInEasing),
-                        repeatMode = RepeatMode.Reverse,
-                    ),
-                label = "icon shake animation",
-            ).value
-        } else {
-            0f
-        }
+        val iconShakeAnimation =
+            if (showVolumeIcon) {
+                rememberInfiniteTransition(label = "icon-infinite")
+                    .animateFloat(
+                        initialValue = -5f,
+                        targetValue = 5f,
+                        animationSpec =
+                            infiniteRepeatable(
+                                animation = tween(100, easing = FastOutLinearInEasing),
+                                repeatMode = RepeatMode.Reverse,
+                            ),
+                        label = "icon shake animation",
+                    ).value
+            } else {
+                0f
+            }
 
         TextButton(
             modifier =
@@ -222,6 +482,7 @@ class EarActivity : AppCompatActivity() {
                     isVolumeLow.value = player.isVolumeLow()
 
                     try {
+                        player.volume = 1.0f
                         player.playWithLoop(index)
                     } catch (e: IOException) {
                         Log.e("EarActivity", "Playing sound", e)
@@ -243,9 +504,10 @@ class EarActivity : AppCompatActivity() {
                                 snackbarHostState.showSnackbar(volumeLowMessage)
                             }
                         },
-                        modifier = Modifier
-                            .size(48.dp)
-                            .graphicsLayer(translationX = iconShakeAnimation),
+                        modifier =
+                            Modifier
+                                .size(48.dp)
+                                .graphicsLayer(translationX = iconShakeAnimation),
                     ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.VolumeOff,

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,4 +5,12 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">El volumen está bajo. Súbelo para escuchar los tonos de afinación.</string>
+  <string name="session_mode_label">Modo sesión</string>
+  <string name="session_stop">Detener</string>
+  <string name="session_no_headphones">No se detectaron auriculares. Conecta auriculares para afinar discretamente.</string>
+  <string name="session_volume_label">Volumen</string>
+  <string name="session_string_1">4 - Re</string>
+  <string name="session_string_2">3 - Sol</string>
+  <string name="session_string_3">2 - Si</string>
+  <string name="session_string_4">1 - Re</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,4 +5,12 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">Il volume è basso. Alzalo per sentire i toni di accordatura.</string>
+  <string name="session_mode_label">Modalità sessione</string>
+  <string name="session_stop">Ferma</string>
+  <string name="session_no_headphones">Nessuna cuffia rilevata. Collega gli auricolari per accordare discretamente.</string>
+  <string name="session_volume_label">Volume</string>
+  <string name="session_string_1">4 - Re</string>
+  <string name="session_string_2">3 - Sol</string>
+  <string name="session_string_3">2 - Si</string>
+  <string name="session_string_4">1 - Re</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -5,4 +5,12 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">O volume está baixo. Aumente para ouvir os tons de afinação.</string>
+  <string name="session_mode_label">Modo sessão</string>
+  <string name="session_stop">Parar</string>
+  <string name="session_no_headphones">Nenhum fone detectado. Conecte fones de ouvido para afinar discretamente.</string>
+  <string name="session_volume_label">Volume</string>
+  <string name="session_string_1">4 - Ré</string>
+  <string name="session_string_2">3 - Sol</string>
+  <string name="session_string_3">2 - Si</string>
+  <string name="session_string_4">1 - Ré</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,12 @@
   <string name="ear_button_3_text">3 - G</string>
   <string name="ear_button_4_text">4 - D</string>
   <string name="volume_low_message">Volume is low. Turn it up to hear the tuning tones.</string>
+  <string name="session_mode_label">Session mode</string>
+  <string name="session_stop">Stop</string>
+  <string name="session_no_headphones">No headphones detected. Plug in earbuds for discreet tuning.</string>
+  <string name="session_volume_label">Volume</string>
+  <string name="session_string_1">4 - D</string>
+  <string name="session_string_2">3 - G</string>
+  <string name="session_string_3">2 - B</string>
+  <string name="session_string_4">1 - D</string>
 </resources>

--- a/app/src/test/java/com/makingiants/android/banjotuner/SessionModeTest.kt
+++ b/app/src/test/java/com/makingiants/android/banjotuner/SessionModeTest.kt
@@ -1,0 +1,52 @@
+package com.makingiants.android.banjotuner
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SessionModeTest {
+    @Test
+    fun `clampVolume at minimum returns 0`() {
+        assertEquals(0.0f, clampVolume(0.0f))
+    }
+
+    @Test
+    fun `clampVolume at maximum returns 1`() {
+        assertEquals(1.0f, clampVolume(1.0f))
+    }
+
+    @Test
+    fun `clampVolume below minimum clamps to 0`() {
+        assertEquals(0.0f, clampVolume(-0.5f))
+    }
+
+    @Test
+    fun `clampVolume above maximum clamps to 1`() {
+        assertEquals(1.0f, clampVolume(1.5f))
+    }
+
+    @Test
+    fun `clampVolume mid-range preserves value`() {
+        assertEquals(0.3f, clampVolume(0.3f))
+    }
+
+    @Test
+    fun `autoAdvanceNextIndex from 0 returns 1`() {
+        assertEquals(1, autoAdvanceNextIndex(0))
+    }
+
+    @Test
+    fun `autoAdvanceNextIndex from 1 returns 2`() {
+        assertEquals(2, autoAdvanceNextIndex(1))
+    }
+
+    @Test
+    fun `autoAdvanceNextIndex from 2 returns 3`() {
+        assertEquals(3, autoAdvanceNextIndex(2))
+    }
+
+    @Test
+    fun `autoAdvanceNextIndex from 3 returns null`() {
+        assertNull(autoAdvanceNextIndex(3))
+    }
+}


### PR DESCRIPTION
## Summary
- Add "Session mode" for discreet tuning through earbuds during live music sessions
- Dark UI with auto-advance sequential playback (5s per string), adjustable per-player volume, headphone detection
- 9 unit tests for volume clamping and auto-advance logic

## User Problem Solved
- **Siobhan K.** (Irish session player) needs discreet earbud tuning between tune sets with only 20-30 seconds available
- **Jake R.** (bluegrass jammer) faces similar pressure at outdoor jams

## Changes
- `SoundPlayer.kt`: Added `volume` field for per-player volume control via `MediaPlayer.setVolume()`, `isHeadphoneConnected()` using `AudioManager.getDevices()`, `clampVolume()`, `autoAdvanceNextIndex()` helper functions, and session constants
- `EarActivity.kt`: Added session mode toggle button with headphone icon, `SessionModeLayout` composable with dark theme, auto-advance via `LaunchedEffect`, volume slider, progress dots, stop button. Back button exits session mode. `onPause` cleans up session state
- `values/strings.xml`: Added session mode labels (session_mode_label, session_stop, session_no_headphones, session_volume_label, session_string_1-4)
- `values-es/strings.xml`: Spanish translations
- `values-pt/strings.xml`: Portuguese translations
- `values-it/strings.xml`: Italian translations
- `SessionModeTest.kt`: 9 unit tests for volume clamping and auto-advance boundary logic

## Artifacts
- Investigation: /Users/dan/projects/banjen/.claude-output/product-team/features/add-session-mode/1-investigation.md
- Plan: /Users/dan/projects/banjen/.claude-output/product-team/features/add-session-mode/2-plan.md

## How to Test
1. Install debug APK on device
2. In normal mode, tap "Session mode" button at top (headphone icon)
3. If no headphones connected, verify snackbar warning appears
4. Session mode activates: dark background, shows first string "4 - D"
5. Auto-advance plays each string for 5 seconds (4 strings total = 20s cycle)
6. Progress dots light up as strings advance
7. Adjust volume slider - verify playback volume changes
8. Tap Stop to exit session mode
9. Press back button during session - should exit session mode (not the app)
10. Kill/background app during session - verify clean exit (no stuck audio)

## Council Endorsement
**Product Council**: This is a direct validated feature request from Siobhan -- "An earbud tone would be perfect." The Chief Product Strategist notes that "session mode" differentiates Banjen from every competitor: no other tuner app is designed for the specific social context of live music sessions. The Strategic Growth Advisor identifies Irish traditional music as a passionate, tight-knit community where word-of-mouth is the primary distribution channel -- a feature designed for sessions would spread organically through session networks.

**Engineering Council**: The Principal Software Architect identifies this as a moderate-complexity feature that builds on existing infrastructure. `MediaPlayer.setVolume(float, float)` already exists and is the mechanism for per-player volume control. Headphone detection via `AudioManager` is straightforward. The auto-advance timer is a simple `LaunchedEffect` with `delay()` in Compose. The Lean Engineering Lead sizes this as M -- no new dependencies, but the interaction design (auto-advance timing, headphone detection UX, dark mode) requires careful polish.

🤖 Generated by product-engineers-team skill