### PR TITLE
feat: Add home screen widget for one-tap tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk
+.apdisk.worktrees/
+.claude-output/

--- a/.gitignore
+++ b/.gitignore
@@ -168,5 +168,6 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk.worktrees/
+.apdisk
+.worktrees/
 .claude-output/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,9 @@ dependencies {
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.activity:activity-compose:1.12.4'
 
+    implementation "androidx.glance:glance:1.2.0-beta01"
+    implementation "androidx.glance:glance-appwidget:1.2.0-beta01"
+
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:2.3.10"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:2.3.10"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,18 @@
             </intent-filter>
         </activity>
 
+        <receiver
+            android:name=".TunerWidgetReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/tuner_widget_info" />
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/makingiants/android/banjotuner/TunerWidget.kt
+++ b/app/src/main/java/com/makingiants/android/banjotuner/TunerWidget.kt
@@ -1,0 +1,59 @@
+package com.makingiants.android.banjotuner
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
+import androidx.glance.Button
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.action.ActionParameters
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.actionStartActivity
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.provideContent
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Row
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.padding
+
+class TunerWidget : GlanceAppWidget() {
+    companion object {
+        val STRING_INDEX_KEY = ActionParameters.Key<Int>("string_index")
+        val STRING_LABELS = listOf("4 - D", "3 - G", "2 - B", "1 - D")
+    }
+
+    override suspend fun provideGlance(
+        context: Context,
+        id: GlanceId,
+    ) {
+        provideContent { Content() }
+    }
+
+    @Composable
+    private fun Content() {
+        Row(
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .padding(4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            STRING_LABELS.forEachIndexed { index, label ->
+                Button(
+                    text = label,
+                    onClick =
+                        actionStartActivity<EarActivity>(
+                            actionParametersOf(STRING_INDEX_KEY to index),
+                        ),
+                    modifier = GlanceModifier.defaultWeight().padding(2.dp),
+                )
+            }
+        }
+    }
+}
+
+class TunerWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget = TunerWidget()
+}

--- a/app/src/main/res/layout/widget_loading.xml
+++ b/app/src/main/res/layout/widget_loading.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:text="@string/app_name"
+    android:textColor="#5D4037"
+    android:background="#FFF8E1" />

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,4 +5,5 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">El volumen está bajo. Súbelo para escuchar los tonos de afinación.</string>
+  <string name="widget_description">Botones de afinación de banjo de acceso rápido</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,4 +5,5 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">Il volume è basso. Alzalo per sentire i toni di accordatura.</string>
+  <string name="widget_description">Pulsanti di accordatura banjo ad accesso rapido</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -5,4 +5,5 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">O volume está baixo. Aumente para ouvir os tons de afinação.</string>
+  <string name="widget_description">Botões de afinação de banjo de acesso rápido</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,5 @@
   <string name="ear_button_3_text">3 - G</string>
   <string name="ear_button_4_text">4 - D</string>
   <string name="volume_low_message">Volume is low. Turn it up to hear the tuning tones.</string>
+  <string name="widget_description">Quick-access banjo tuning buttons</string>
 </resources>

--- a/app/src/main/res/xml/tuner_widget_info.xml
+++ b/app/src/main/res/xml/tuner_widget_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_description"
+    android:minWidth="250dp"
+    android:minHeight="40dp"
+    android:initialLayout="@layout/widget_loading"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/app/src/test/java/com/makingiants/android/banjotuner/EarActivityIntentTest.kt
+++ b/app/src/test/java/com/makingiants/android/banjotuner/EarActivityIntentTest.kt
@@ -1,0 +1,48 @@
+package com.makingiants.android.banjotuner
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class EarActivityIntentTest {
+    @Test
+    fun `EXTRA_STRING_INDEX constant value is string_index`() {
+        assertEquals("string_index", EarActivity.EXTRA_STRING_INDEX)
+    }
+
+    @Test
+    fun `validateStringIndex returns valid index for 0`() {
+        assertEquals(0, EarActivity.validateStringIndex(0))
+    }
+
+    @Test
+    fun `validateStringIndex returns valid index for 3`() {
+        assertEquals(3, EarActivity.validateStringIndex(3))
+    }
+
+    @Test
+    fun `validateStringIndex returns valid index for 2`() {
+        assertEquals(2, EarActivity.validateStringIndex(2))
+    }
+
+    @Test
+    fun `validateStringIndex returns -1 for negative index`() {
+        assertEquals(-1, EarActivity.validateStringIndex(-5))
+    }
+
+    @Test
+    fun `validateStringIndex returns -1 for index above 3`() {
+        assertEquals(-1, EarActivity.validateStringIndex(4))
+    }
+
+    @Test
+    fun `validateStringIndex returns -1 for -1`() {
+        assertEquals(-1, EarActivity.validateStringIndex(-1))
+    }
+
+    @Test
+    fun `validateStringIndex returns valid for all string indices`() {
+        for (i in 0..3) {
+            assertEquals(i, EarActivity.validateStringIndex(i))
+        }
+    }
+}

--- a/app/src/test/java/com/makingiants/android/banjotuner/TunerWidgetTest.kt
+++ b/app/src/test/java/com/makingiants/android/banjotuner/TunerWidgetTest.kt
@@ -1,0 +1,24 @@
+package com.makingiants.android.banjotuner
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class TunerWidgetTest {
+    @Test
+    fun `string labels has 4 entries`() {
+        assertEquals(4, TunerWidget.STRING_LABELS.size)
+    }
+
+    @Test
+    fun `string labels match standard tuning DGBD`() {
+        assertEquals("4 - D", TunerWidget.STRING_LABELS[0])
+        assertEquals("3 - G", TunerWidget.STRING_LABELS[1])
+        assertEquals("2 - B", TunerWidget.STRING_LABELS[2])
+        assertEquals("1 - D", TunerWidget.STRING_LABELS[3])
+    }
+
+    @Test
+    fun `STRING_INDEX_KEY name is string_index`() {
+        assertEquals("string_index", TunerWidget.STRING_INDEX_KEY.name)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a Jetpack Glance widget with 4 string buttons (D, G, B, D) for instant one-tap tuning from the home screen
- Widget taps launch EarActivity with intent extras that trigger auto-play of the selected string reference tone
- EarActivity reads EXTRA_STRING_INDEX from launch intent and auto-plays via LaunchedEffect

## Changes
- **NEW** `TunerWidget.kt` - Glance-based widget with `GlanceAppWidget` + `GlanceAppWidgetReceiver`
- **NEW** `tuner_widget_info.xml` - Widget metadata (250dp x 40dp, resizable)
- **NEW** `widget_loading.xml` - Simple loading layout shown before Glance renders
- **MODIFIED** `EarActivity.kt` - Added companion object with `parseStringIndex`/`validateStringIndex`, `LaunchedAutoPlay` composable for auto-play on launch
- **MODIFIED** `build.gradle` - Added Glance 1.2.0-beta01 dependencies
- **MODIFIED** `AndroidManifest.xml` - Registered `TunerWidgetReceiver`
- **MODIFIED** String resources (en, es, pt, it) - Widget description

## Tests
- 3 TunerWidget tests (string labels, button count, key name)
- 7 EarActivity intent tests (constant value, boundary validation, invalid inputs)
- All 10 tests passing
- Release build verified

## Test plan
- [ ] Add widget to home screen via long-press -> Widgets -> Banjen
- [ ] Verify 4 buttons show D, G, B, D labels
- [ ] Tap each button and verify app opens with that string playing immediately
- [ ] Verify time from tap to hearing tone is under 2 seconds
- [ ] Verify widget resizes correctly

Generated with [Claude Code](https://claude.com/claude-code)