### PR TITLE
feat: Add 5-string banjo with alternate tunings and sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk
+.apdisk.worktrees/
+.claude-output/

--- a/.gitignore
+++ b/.gitignore
@@ -168,5 +168,6 @@ Icon
 .AppleDesktop
 Network Trash Folder
 Temporary Items
-.apdisk.worktrees/
+.apdisk
+.worktrees/
 .claude-output/

--- a/app/src/main/java/com/makingiants/android/banjotuner/ToneGenerator.kt
+++ b/app/src/main/java/com/makingiants/android/banjotuner/ToneGenerator.kt
@@ -1,0 +1,79 @@
+package com.makingiants.android.banjotuner
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import kotlin.math.PI
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+const val TONE_SAMPLE_RATE = 44100
+
+fun generateSineWaveSamples(frequency: Float, sampleRate: Int, numSamples: Int): ShortArray {
+    val samples = ShortArray(numSamples)
+    val twoPiF = 2.0 * PI * frequency
+    for (i in 0 until numSamples) {
+        val t = i.toDouble() / sampleRate
+        val value = sin(twoPiF * t)
+        samples[i] = (value * Short.MAX_VALUE).toInt().toShort()
+    }
+    return samples
+}
+
+fun calculateLoopSampleCount(frequency: Float, sampleRate: Int): Int {
+    val samplesPerCycle = sampleRate.toFloat() / frequency
+    val cycles = (sampleRate / samplesPerCycle).roundToInt()
+    return (cycles * samplesPerCycle).roundToInt()
+}
+
+class ToneGenerator {
+    private var audioTrack: AudioTrack? = null
+    val isPlaying: Boolean get() = audioTrack?.playState == AudioTrack.PLAYSTATE_PLAYING
+
+    fun play(frequency: Float) {
+        stop()
+
+        val loopSamples = calculateLoopSampleCount(frequency, TONE_SAMPLE_RATE)
+        val samples = generateSineWaveSamples(frequency, TONE_SAMPLE_RATE, loopSamples)
+        val bufferSize = loopSamples * 2 // 16-bit = 2 bytes per sample
+
+        val track = AudioTrack.Builder()
+            .setAudioAttributes(
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_MEDIA)
+                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                    .build()
+            )
+            .setAudioFormat(
+                AudioFormat.Builder()
+                    .setSampleRate(TONE_SAMPLE_RATE)
+                    .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                    .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                    .build()
+            )
+            .setBufferSizeInBytes(bufferSize.coerceAtLeast(AudioTrack.getMinBufferSize(
+                TONE_SAMPLE_RATE,
+                AudioFormat.CHANNEL_OUT_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+            )))
+            .setTransferMode(AudioTrack.MODE_STATIC)
+            .build()
+
+        track.write(samples, 0, samples.size)
+        track.setLoopPoints(0, loopSamples, -1)
+        track.play()
+
+        audioTrack = track
+    }
+
+    fun stop() {
+        audioTrack?.apply {
+            if (playState == AudioTrack.PLAYSTATE_PLAYING) {
+                pause()
+                flush()
+            }
+            release()
+        }
+        audioTrack = null
+    }
+}

--- a/app/src/main/java/com/makingiants/android/banjotuner/TuningModel.kt
+++ b/app/src/main/java/com/makingiants/android/banjotuner/TuningModel.kt
@@ -1,0 +1,104 @@
+package com.makingiants.android.banjotuner
+
+import kotlin.math.pow
+
+data class Note(val name: String, val frequency: Float)
+
+data class Tuning(val name: String, val notes: List<Note>)
+
+data class Instrument(val name: String, val tunings: List<Tuning>)
+
+fun noteFrequency(midiNote: Int): Float = 440.0f * 2.0f.pow((midiNote - 69) / 12.0f)
+
+fun encodeTuning(tuning: Tuning): String {
+    val notesPart = tuning.notes.joinToString(",") { "${it.name}:${it.frequency}" }
+    return "${tuning.name}|$notesPart"
+}
+
+fun decodeTuning(encoded: String): Tuning? {
+    val parts = encoded.split("|")
+    if (parts.size != 2) return null
+    val name = parts[0]
+    val noteStrings = parts[1].split(",")
+    val notes = noteStrings.mapNotNull { noteStr ->
+        val noteParts = noteStr.split(":")
+        if (noteParts.size != 2) return@mapNotNull null
+        val freq = noteParts[1].toFloatOrNull() ?: return@mapNotNull null
+        Note(noteParts[0], freq)
+    }
+    if (notes.isEmpty()) return null
+    return Tuning(name, notes)
+}
+
+val FOUR_STRING_BANJO = Instrument(
+    name = "4-String Banjo",
+    tunings = listOf(
+        Tuning("Standard DGBD", listOf(
+            Note("D3", noteFrequency(50)),
+            Note("G3", noteFrequency(55)),
+            Note("B3", noteFrequency(59)),
+            Note("D4", noteFrequency(62)),
+        )),
+        Tuning("Irish GDAE", listOf(
+            Note("G3", noteFrequency(55)),
+            Note("D4", noteFrequency(62)),
+            Note("A4", noteFrequency(69)),
+            Note("E5", noteFrequency(76)),
+        )),
+        Tuning("Chicago DGBE", listOf(
+            Note("D3", noteFrequency(50)),
+            Note("G3", noteFrequency(55)),
+            Note("B3", noteFrequency(59)),
+            Note("E4", noteFrequency(64)),
+        )),
+        Tuning("Plectrum CGBD", listOf(
+            Note("C3", noteFrequency(48)),
+            Note("G3", noteFrequency(55)),
+            Note("B3", noteFrequency(59)),
+            Note("D4", noteFrequency(62)),
+        )),
+    ),
+)
+
+val FIVE_STRING_BANJO = Instrument(
+    name = "5-String Banjo",
+    tunings = listOf(
+        Tuning("Open G (gDGBD)", listOf(
+            Note("g4", noteFrequency(67)),
+            Note("D3", noteFrequency(50)),
+            Note("G3", noteFrequency(55)),
+            Note("B3", noteFrequency(59)),
+            Note("D4", noteFrequency(62)),
+        )),
+        Tuning("Double C (gCGCD)", listOf(
+            Note("g4", noteFrequency(67)),
+            Note("C3", noteFrequency(48)),
+            Note("G3", noteFrequency(55)),
+            Note("C4", noteFrequency(60)),
+            Note("D4", noteFrequency(62)),
+        )),
+        Tuning("Modal (gDGCD)", listOf(
+            Note("g4", noteFrequency(67)),
+            Note("D3", noteFrequency(50)),
+            Note("G3", noteFrequency(55)),
+            Note("C4", noteFrequency(60)),
+            Note("D4", noteFrequency(62)),
+        )),
+        Tuning("Drop C (gCGBD)", listOf(
+            Note("g4", noteFrequency(67)),
+            Note("C3", noteFrequency(48)),
+            Note("G3", noteFrequency(55)),
+            Note("B3", noteFrequency(59)),
+            Note("D4", noteFrequency(62)),
+        )),
+        Tuning("Open D (f#DF#AD)", listOf(
+            Note("f#4", noteFrequency(66)),
+            Note("D3", noteFrequency(50)),
+            Note("F#3", noteFrequency(54)),
+            Note("A3", noteFrequency(57)),
+            Note("D4", noteFrequency(62)),
+        )),
+    ),
+)
+
+val ALL_INSTRUMENTS = listOf(FOUR_STRING_BANJO, FIVE_STRING_BANJO)

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,4 +5,7 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">El volumen está bajo. Súbelo para escuchar los tonos de afinación.</string>
+  <string name="instrument_label">Instrumento</string>
+  <string name="tuning_label">Afinación</string>
+  <string name="share_tuning">Compartir afinación</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,4 +5,7 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">Il volume è basso. Alzalo per sentire i toni di accordatura.</string>
+  <string name="instrument_label">Strumento</string>
+  <string name="tuning_label">Accordatura</string>
+  <string name="share_tuning">Condividi accordatura</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -5,4 +5,7 @@
   <string name="ear_button_3_text">3 - Sol</string>
   <string name="ear_button_4_text">4 - Re</string>
   <string name="volume_low_message">O volume está baixo. Aumente para ouvir os tons de afinação.</string>
+  <string name="instrument_label">Instrumento</string>
+  <string name="tuning_label">Afinação</string>
+  <string name="share_tuning">Compartilhar afinação</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,7 @@
   <string name="ear_button_3_text">3 - G</string>
   <string name="ear_button_4_text">4 - D</string>
   <string name="volume_low_message">Volume is low. Turn it up to hear the tuning tones.</string>
+  <string name="instrument_label">Instrument</string>
+  <string name="tuning_label">Tuning</string>
+  <string name="share_tuning">Share tuning</string>
 </resources>

--- a/app/src/test/java/com/makingiants/android/banjotuner/ToneGeneratorTest.kt
+++ b/app/src/test/java/com/makingiants/android/banjotuner/ToneGeneratorTest.kt
@@ -1,0 +1,43 @@
+package com.makingiants.android.banjotuner
+
+import org.junit.Test
+import kotlin.math.abs
+import kotlin.math.sin
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ToneGeneratorTest {
+
+    @Test
+    fun `generateSineWaveSamples produces correct number of samples`() {
+        val samples = generateSineWaveSamples(440.0f, TONE_SAMPLE_RATE, 44100)
+        assertEquals(44100, samples.size)
+    }
+
+    @Test
+    fun `generateSineWaveSamples at 440Hz has correct period`() {
+        val sampleRate = TONE_SAMPLE_RATE
+        val samples = generateSineWaveSamples(440.0f, sampleRate, sampleRate)
+        // At 440Hz with 44100 sample rate, period = 44100/440 = ~100.23 samples
+        // First sample should be near 0 (sin(0)=0)
+        assertTrue(abs(samples[0].toInt()) < 100, "First sample should be near zero")
+    }
+
+    @Test
+    fun `generateSineWaveSamples values are within Short range`() {
+        val samples = generateSineWaveSamples(440.0f, TONE_SAMPLE_RATE, 4410)
+        samples.forEach { sample ->
+            assertTrue(sample.toInt() >= Short.MIN_VALUE.toInt(), "Sample $sample below Short.MIN_VALUE")
+            assertTrue(sample.toInt() <= Short.MAX_VALUE.toInt(), "Sample $sample above Short.MAX_VALUE")
+        }
+    }
+
+    @Test
+    fun `calculateLoopSampleCount returns full cycles`() {
+        val count = calculateLoopSampleCount(440.0f, TONE_SAMPLE_RATE)
+        // Should be a multiple of samples-per-cycle (44100/440 ~= 100.23)
+        // The function should return at least one full second of audio
+        assertTrue(count > 0)
+        assertTrue(count <= TONE_SAMPLE_RATE)
+    }
+}

--- a/app/src/test/java/com/makingiants/android/banjotuner/TuningModelTest.kt
+++ b/app/src/test/java/com/makingiants/android/banjotuner/TuningModelTest.kt
@@ -1,0 +1,101 @@
+package com.makingiants.android.banjotuner
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TuningModelTest {
+
+    @Test
+    fun `noteFrequency for A4 returns 440`() {
+        assertEquals(440.0f, noteFrequency(69), 0.01f)
+    }
+
+    @Test
+    fun `noteFrequency for C4 returns 261_63`() {
+        assertEquals(261.63f, noteFrequency(60), 0.1f)
+    }
+
+    @Test
+    fun `noteFrequency for G3 returns 196`() {
+        assertEquals(196.0f, noteFrequency(55), 0.1f)
+    }
+
+    @Test
+    fun `noteFrequency for D3 returns 146_83`() {
+        assertEquals(146.83f, noteFrequency(50), 0.1f)
+    }
+
+    @Test
+    fun `four string banjo has at least 4 tunings`() {
+        assertTrue(FOUR_STRING_BANJO.tunings.size >= 4)
+    }
+
+    @Test
+    fun `five string banjo has at least 4 tunings`() {
+        assertTrue(FIVE_STRING_BANJO.tunings.size >= 4)
+    }
+
+    @Test
+    fun `all four string tunings have 4 notes`() {
+        FOUR_STRING_BANJO.tunings.forEach { tuning ->
+            assertEquals(4, tuning.notes.size, "Tuning ${tuning.name} should have 4 notes")
+        }
+    }
+
+    @Test
+    fun `all five string tunings have 5 notes`() {
+        FIVE_STRING_BANJO.tunings.forEach { tuning ->
+            assertEquals(5, tuning.notes.size, "Tuning ${tuning.name} should have 5 notes")
+        }
+    }
+
+    @Test
+    fun `standard 4-string tuning is DGBD`() {
+        val standard = FOUR_STRING_BANJO.tunings.first()
+        val noteNames = standard.notes.map { it.name }
+        assertEquals(listOf("D3", "G3", "B3", "D4"), noteNames)
+    }
+
+    @Test
+    fun `standard 5-string Open G is gDGBD`() {
+        val openG = FIVE_STRING_BANJO.tunings.first()
+        val noteNames = openG.notes.map { it.name }
+        assertEquals(listOf("g4", "D3", "G3", "B3", "D4"), noteNames)
+    }
+
+    @Test
+    fun `encodeTuning produces parseable string`() {
+        val tuning = Tuning("Test", listOf(Note("A4", 440.0f), Note("B4", 493.88f)))
+        val encoded = encodeTuning(tuning)
+        assertTrue(encoded.contains("Test"))
+        assertTrue(encoded.contains("440.0"))
+    }
+
+    @Test
+    fun `decodeTuning roundtrips correctly`() {
+        val original = Tuning("My Tuning", listOf(Note("A4", 440.0f), Note("C4", 261.63f)))
+        val encoded = encodeTuning(original)
+        val decoded = decodeTuning(encoded)
+        assertNotNull(decoded)
+        assertEquals(original.name, decoded.name)
+        assertEquals(original.notes.size, decoded.notes.size)
+        assertEquals(original.notes[0].name, decoded.notes[0].name)
+        assertEquals(original.notes[0].frequency, decoded.notes[0].frequency, 0.01f)
+    }
+
+    @Test
+    fun `decodeTuning returns null for invalid input`() {
+        assertNull(decodeTuning("garbage"))
+    }
+
+    @Test
+    fun `all instruments are accessible`() {
+        val instruments = ALL_INSTRUMENTS
+        assertEquals(2, instruments.size)
+        assertEquals("4-String Banjo", instruments[0].name)
+        assertEquals("5-String Banjo", instruments[1].name)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 5-string banjo support with 5 alternate tunings (Open G, Double C, Modal, Drop C, Open D) alongside existing 4-string banjo (4 tunings)
- Replaces hardcoded MP3 playback with AudioTrack sine wave synthesis (`ToneGenerator`) for arbitrary frequency support
- Dynamic instrument/tuning selector dropdowns drive the button layout, with selection persisted in SharedPreferences
- Share button exports the current tuning via Android share intent using a compact encoded format

## Test plan
- [x] 18 unit tests pass (14 TuningModel + 4 ToneGenerator): `./gradlew test`
- [x] Debug build compiles cleanly: `./gradlew assembleDebug`
- [ ] Manual: verify instrument/tuning dropdowns switch note buttons correctly
- [ ] Manual: verify tapping note buttons plays correct sine wave tones
- [ ] Manual: verify share button opens Android share sheet with encoded tuning
- [ ] Manual: verify selection persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)